### PR TITLE
Update README.md and use.md in codeTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 1. Git clone our repository
 2. creating conda environment:
 ```shell
-conda create -n LLMenv python=3.8
+conda create -n LLMenv python=3.10
 conda activate LLMenv
 conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia
+pip install sympy==1.13.1
 pip install --upgrade transformers
 conda install psutil
 pip install peft

--- a/codeTool/use.md
+++ b/codeTool/use.md
@@ -1,7 +1,7 @@
 ### Create an docker instance for code execution
 
 #### 1. Download docker image
-Download address://github.com/criyle/go-judge?tab=readme-ov-file
+Download address: https://github.com/criyle/go-judge?tab=readme-ov-file
 
 #### 2. Create a docker instance
 ```
@@ -16,7 +16,7 @@ apt update && apt install python3
 
 #### For performing operations inside a running Docker container (if needed)
 ```
-docker exec -it go-judge /bin/bash
+sudo docker exec -it go-judge /bin/bash
 ```
 #### Restart (if necessary)
 ```
@@ -27,7 +27,7 @@ sudo docker restart go-judge
 #### A simple usage example
 1.Modify codecontent and test points in the directory (test_directory) in codeTool.ExecutiveProgram.TestExample.RunProgramAndTestPostion.Py 
 
-2.In the CodeTool/ directory, run the following command:
+2.In the codeTool/ directory, run the following command:
 ```
 python -m ExecutiveProgram.TestExample.RunProgramAndTestPostion
 ```


### PR DESCRIPTION
Update `README.md`   to change python version from `3.8` to `3.10` since `alignment-handbook` [requires](https://github.com/huggingface/alignment-handbook/blob/205b881c8065666036b0034be38e1e622fdcbf8d/setup.py#L134) minimum `3.10.9`, and `use.md` in `codeTool` to fix minor typos.